### PR TITLE
fix: DB falsely marked offline on migration failure; add IF NOT EXISTS to migration 006

### DIFF
--- a/migrations/006_profiles_and_requests_schema.sql
+++ b/migrations/006_profiles_and_requests_schema.sql
@@ -4,8 +4,8 @@
 
 -- Add missing profile columns for bio and links, and enforce one profile per user.
 ALTER TABLE profiles
-    ADD COLUMN bio TEXT,
-    ADD COLUMN links TEXT;
+    ADD COLUMN IF NOT EXISTS bio TEXT,
+    ADD COLUMN IF NOT EXISTS links TEXT;
 
 ALTER TABLE profiles
     ADD CONSTRAINT unique_profile_user_id UNIQUE (user_id);

--- a/src/core/app.py
+++ b/src/core/app.py
@@ -51,13 +51,20 @@ def build_bot() -> commands.Bot:
 async def initialize_database() -> None:
     try:
         await db.connect()
-        await db.run_migrations()
         runtime_state.db_available = True
-        logger.info('PostgreSQL database connected and migrations applied')
+        logger.info('PostgreSQL database connected')
     except Exception as exc:
         runtime_state.db_available = False
         runtime_state.degraded_features.append('database')
-        logger.error('Database startup failed: %s', exc, exc_info=True)
+        logger.error('Database connection failed: %s', exc, exc_info=True)
+        return
+
+    try:
+        await db.run_migrations()
+        logger.info('Database migrations applied')
+    except Exception as exc:
+        logger.error('Database migrations failed (DB remains available): %s', exc, exc_info=True)
+        runtime_state.degraded_features.append('migrations')
 
 
 def load_extensions(bot: commands.Bot, extensions: List[str]) -> None:


### PR DESCRIPTION
- Separate DB connection from migration failure handling so a failed
  migration script doesn't flip db_available to False
- Add IF NOT EXISTS to ADD COLUMN in migration 006 to prevent errors
  on re-run
