### PR TITLE
fix: prevent data errors from poisoning db_available; fix marketplace category insert

### DIFF
--- a/src/cogs/marketplace/marketplace.py
+++ b/src/cogs/marketplace/marketplace.py
@@ -53,18 +53,22 @@ class Marketplace(commands.Cog):
             return
 
         # Fetch category ID based on the provided name
-        category_record = await db.fetch_one('SELECT id FROM marketplace_categories WHERE name = $1 LIMIT 1', category)
+        category_record = await db.fetch_one('SELECT id FROM marketplace_categories WHERE name = $1', category)
         if not category_record:
-            # Fallback to inserting category if it doesn't exist to ensure robustness
-            cat_id = f'CAT_{category.upper()}'
+            # Fallback: insert with SERIAL auto-generated id, then re-fetch
             await db.execute(
-                "INSERT INTO marketplace_categories (id, name, emoji, is_active) VALUES ($1, $2, '📦', TRUE) ON CONFLICT DO NOTHING",
-                cat_id,
+                "INSERT INTO marketplace_categories (name, emoji, is_active) VALUES ($1, '📦', TRUE) ON CONFLICT DO NOTHING",
                 category,
             )
-            category_id = cat_id
-        else:
-            category_id = category_record['id']
+            category_record = await db.fetch_one('SELECT id FROM marketplace_categories WHERE name = $1', category)
+            if not category_record:
+                embed = error_embed(
+                    'Category Error', 'Could not find or create the category.', contributor_source=__name__
+                )
+                await safe_send(interaction, embed=embed, ephemeral=True)
+                return
+
+        category_id = category_record['id']
 
         listing_id = f'MP{int(datetime.datetime.utcnow().timestamp())}'
 

--- a/src/database/database.py
+++ b/src/database/database.py
@@ -82,9 +82,12 @@ class Database:
         try:
             async with self.pool.acquire() as connection:
                 return await connection.fetchrow(query, *args)
-        except asyncpg.PostgresError as exc:
+        except (asyncpg.ConnectionFailureError, asyncpg.InterfaceError) as exc:
             runtime_state.db_available = False
-            logger.error('Database fetch_one failed: %s | query=%s | args=%s', exc, query, args, exc_info=True)
+            logger.error('Database connection error: %s | query=%s | args=%s', exc, query, args, exc_info=True)
+            raise DatabaseUnavailableError('Database unavailable') from exc
+        except asyncpg.PostgresError as exc:
+            logger.error('Database query error: %s | query=%s | args=%s', exc, query, args, exc_info=True)
             raise DatabaseUnavailableError('Database query failed') from exc
 
     async def fetchrow(self, query: str, *args: Any) -> asyncpg.Record | None:
@@ -98,9 +101,12 @@ class Database:
         try:
             async with self.pool.acquire() as connection:
                 return await connection.fetch(query, *args)
-        except asyncpg.PostgresError as exc:
+        except (asyncpg.ConnectionFailureError, asyncpg.InterfaceError) as exc:
             runtime_state.db_available = False
-            logger.error('Database fetch failed: %s | query=%s | args=%s', exc, query, args, exc_info=True)
+            logger.error('Database connection error: %s | query=%s | args=%s', exc, query, args, exc_info=True)
+            raise DatabaseUnavailableError('Database unavailable') from exc
+        except asyncpg.PostgresError as exc:
+            logger.error('Database query error: %s | query=%s | args=%s', exc, query, args, exc_info=True)
             raise DatabaseUnavailableError('Database query failed') from exc
 
     async def fetch_many(self, query: str, *args: Any):
@@ -114,9 +120,12 @@ class Database:
         try:
             async with self.pool.acquire() as connection:
                 return await connection.fetchval(query, *args)
-        except asyncpg.PostgresError as exc:
+        except (asyncpg.ConnectionFailureError, asyncpg.InterfaceError) as exc:
             runtime_state.db_available = False
-            logger.error('Database fetchval failed: %s | query=%s | args=%s', exc, query, args, exc_info=True)
+            logger.error('Database connection error: %s | query=%s | args=%s', exc, query, args, exc_info=True)
+            raise DatabaseUnavailableError('Database unavailable') from exc
+        except asyncpg.PostgresError as exc:
+            logger.error('Database query error: %s | query=%s | args=%s', exc, query, args, exc_info=True)
             raise DatabaseUnavailableError('Database query failed') from exc
 
     async def execute(self, query: str, *args: Any) -> str:
@@ -127,9 +136,12 @@ class Database:
         try:
             async with self.pool.acquire() as connection:
                 return await connection.execute(query, *args)
-        except asyncpg.PostgresError as exc:
+        except (asyncpg.ConnectionFailureError, asyncpg.InterfaceError) as exc:
             runtime_state.db_available = False
-            logger.error('Database execute failed: %s | query=%s | args=%s', exc, query, args, exc_info=True)
+            logger.error('Database connection error: %s | query=%s | args=%s', exc, query, args, exc_info=True)
+            raise DatabaseUnavailableError('Database unavailable') from exc
+        except asyncpg.PostgresError as exc:
+            logger.error('Database query error: %s | query=%s | args=%s', exc, query, args, exc_info=True)
             raise DatabaseUnavailableError('Database query failed') from exc
 
     async def execute_many(self, query: str, args_list: list[tuple[Any, ...]]) -> None:
@@ -140,11 +152,14 @@ class Database:
         try:
             async with self.pool.acquire() as connection:
                 await connection.executemany(query, args_list)
-        except asyncpg.PostgresError as exc:
+        except (asyncpg.ConnectionFailureError, asyncpg.InterfaceError) as exc:
             runtime_state.db_available = False
             logger.error(
-                'Database execute_many failed: %s | query=%s | args_list=%s', exc, query, args_list, exc_info=True
+                'Database connection error: %s | query=%s | args_list=%s', exc, query, args_list, exc_info=True
             )
+            raise DatabaseUnavailableError('Database unavailable') from exc
+        except asyncpg.PostgresError as exc:
+            logger.error('Database query error: %s | query=%s | args_list=%s', exc, query, args_list, exc_info=True)
             raise DatabaseUnavailableError('Database query failed') from exc
 
     async def run_migrations(self) -> None:


### PR DESCRIPTION
database.py:
- Split PostgresError handling: connection failures (ConnectionFailureError,
  InterfaceError) set db_available=False; data/query errors no longer poison
  the runtime state, so a single bad query can't gate all subsequent commands

marketplace.py:
- Category fallback insert no longer passes a string id to SERIAL column
  (was 'CAT_HARDWARE' into integer PK). Uses auto-generated id + re-fetch.
- Returns a clear error embed if category creation genuinely fails
