### PR TITLE
refactor: extract shared aiohttp session to src/utils/http.py

### DIFF
--- a/src/core/app.py
+++ b/src/core/app.py
@@ -285,17 +285,17 @@ def configure_bot_events(bot: commands.Bot) -> None:
             interaction, content='An internal error occurred while processing your command.', ephemeral=True
         )
 
-    # Close the shared Directus sync session on real shutdown (not on transient
-    # gateway disconnects). bot.close() is nextcord's canonical shutdown path.
+    # Close the shared HTTP session on real shutdown (not on transient gateway
+    # disconnects). bot.close() is nextcord's canonical shutdown path.
     _default_close = bot.close
 
     async def _close_with_cleanup() -> None:
-        from src.services import directus_sync
+        from src.utils import http
 
         try:
-            await directus_sync.aclose()
+            await http.aclose()
         except Exception as exc:
-            logger.warning('Error closing Directus sync session: %s', exc)
+            logger.warning('Error closing shared HTTP session: %s', exc)
         await _default_close()
 
     bot.close = _close_with_cleanup  # type: ignore[method-assign]

--- a/src/services/directus_sync.py
+++ b/src/services/directus_sync.py
@@ -14,31 +14,11 @@ from typing import Any
 import aiohttp
 
 from src.config.config import DIRECTUS_SERVICE_TOKEN, DIRECTUS_SYNC_ENABLED, DIRECTUS_URL
+from src.utils.http import get_session
 
 logger = logging.getLogger('VEKA.directus_sync')
 
-_TIMEOUT = aiohttp.ClientTimeout(total=10)
 _LISTINGS = 'marketplace_listings'
-
-# One session reused for the bot's lifetime — keeps the connection pool warm
-# instead of building a new one per call. Created lazily inside the running loop
-# (never at import) and closed via aclose() on shutdown.
-_session: aiohttp.ClientSession | None = None
-
-
-def _get_session() -> aiohttp.ClientSession:
-    global _session
-    if _session is None or _session.closed:
-        _session = aiohttp.ClientSession(timeout=_TIMEOUT)
-    return _session
-
-
-async def aclose() -> None:
-    """Close the shared session. Call once on bot shutdown."""
-    global _session
-    if _session is not None and not _session.closed:
-        await _session.close()
-    _session = None
 
 
 def _headers() -> dict[str, str]:
@@ -73,7 +53,7 @@ async def upsert_listing(listing: dict[str, Any]) -> None:
     if not DIRECTUS_SYNC_ENABLED:
         return
     try:
-        session = _get_session()
+        session = get_session()
         payload = {k: v for k, v in listing.items() if v is not None}
 
         profile_id = await _resolve_profile_id(session, str(listing['seller_discord_id']))
@@ -100,7 +80,7 @@ async def set_listing_status(external_ref: str, status: str) -> None:
     if not DIRECTUS_SYNC_ENABLED:
         return
     try:
-        session = _get_session()
+        session = get_session()
         item_id = await _find_listing_id(session, external_ref)
         if not item_id:
             return

--- a/src/services/rss_service.py
+++ b/src/services/rss_service.py
@@ -8,6 +8,7 @@ from bs4 import BeautifulSoup
 
 from src.config.config import RSS_FEEDS
 from src.database.database import db
+from src.utils.http import get_session
 from src.utils.safety import DatabaseUnavailableError, ExternalRequestError
 
 logger = logging.getLogger('VEKA.rss')
@@ -20,11 +21,11 @@ class RSSService:
     async def fetch_feed(self, url: str) -> dict | None:
         try:
             headers = {'User-Agent': 'VEKA-DiscordBot/1.0'}
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url, headers=headers, timeout=aiohttp.ClientTimeout(total=10)) as response:
-                    if response.status != 200:
-                        raise ExternalRequestError(f'HTTP Status: {response.status}')
-                    content = await response.text()
+            session = get_session()
+            async with session.get(url, headers=headers, timeout=aiohttp.ClientTimeout(total=10)) as response:
+                if response.status != 200:
+                    raise ExternalRequestError(f'HTTP Status: {response.status}')
+                content = await response.text()
 
             feed = feedparser.parse(content)
             processed_entries = []

--- a/src/utils/http.py
+++ b/src/utils/http.py
@@ -1,0 +1,27 @@
+"""Shared aiohttp session for the bot's lifetime.
+
+A single session keeps its connection pool warm across calls instead of building
+a new one per request. Created lazily inside the running loop (never at import)
+and closed once on shutdown via aclose(). Per-request timeouts can still be
+passed to individual .get()/.post() calls to override the default.
+"""
+
+import aiohttp
+
+_DEFAULT_TIMEOUT = aiohttp.ClientTimeout(total=10)
+_session: aiohttp.ClientSession | None = None
+
+
+def get_session() -> aiohttp.ClientSession:
+    global _session
+    if _session is None or _session.closed:
+        _session = aiohttp.ClientSession(timeout=_DEFAULT_TIMEOUT)
+    return _session
+
+
+async def aclose() -> None:
+    """Close the shared session. Call once on bot shutdown."""
+    global _session
+    if _session is not None and not _session.closed:
+        await _session.close()
+    _session = None


### PR DESCRIPTION
- New  with lazy  and  for
  a single aiohttp.ClientSession reused across the bot lifetime.
-  delegates session management to http utility.
-  switches from per-request sessions to the shared
  pool (connection reuse, less overhead).
-  shutdown cleanup updated to call .
